### PR TITLE
feat(MB-64 & MB-63): Create premium GROUPs routes with POST and GET

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,8 +2,9 @@ import { Module } from '@nestjs/common';
 import { CustomerModule } from './customer/customer.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { ConfigModule } from '@nestjs/config';
+import { GroupModule } from './group/group.module';
 
 @Module({
-  imports: [CustomerModule, PrismaModule, ConfigModule.forRoot()]
+  imports: [CustomerModule, PrismaModule, ConfigModule.forRoot(), GroupModule]
 })
 export class AppModule {}

--- a/src/group/dto/create-group.dto.ts
+++ b/src/group/dto/create-group.dto.ts
@@ -1,0 +1,23 @@
+import { IsString, IsUUID } from "class-validator";
+import { Group } from "../entities/group.entity";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CreateGroupDto extends Group {
+
+  @IsString()
+  @ApiProperty({
+    description: 'Group id',
+    default: "557388015449-1234567890@g.us",
+    type: String
+})
+  chatId: string;
+
+  @IsUUID()
+  @ApiProperty({
+    description: 'Customer id',
+    default: "54d4e70b-3e70-4394-ab8c-bb3e551975ce",
+    type: String
+})
+  customerId: string;
+
+}

--- a/src/group/dto/get-customer.dto.ts
+++ b/src/group/dto/get-customer.dto.ts
@@ -1,0 +1,3 @@
+import { Group } from "../entities/group.entity";
+
+export class GetCustomerDto extends Group{}

--- a/src/group/dto/get-group.dto.ts
+++ b/src/group/dto/get-group.dto.ts
@@ -1,3 +1,3 @@
 import { Group } from "../entities/group.entity";
 
-export class GetCustomerDto extends Group{}
+export class GetGroupDto extends Group{}

--- a/src/group/dto/update-group.dto.ts
+++ b/src/group/dto/update-group.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateGroupDto } from './create-group.dto';
+
+export class UpdateGroupDto extends PartialType(CreateGroupDto) {}

--- a/src/group/entities/group.entity.ts
+++ b/src/group/entities/group.entity.ts
@@ -1,0 +1,9 @@
+import { Prisma } from "@prisma/client";
+
+export class Group implements Prisma.GroupUncheckedCreateInput {
+  id?: string;
+  chatId: string;
+  customerId?: string;
+  createdAt?: string | Date;
+  createdBy?: string;
+}

--- a/src/group/group.controller.spec.ts
+++ b/src/group/group.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GroupController } from './group.controller';
+import { GroupService } from './group.service';
+
+describe('GroupController', () => {
+  let controller: GroupController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GroupController],
+      providers: [GroupService],
+    }).compile();
+
+    controller = module.get<GroupController>(GroupController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/group/group.controller.ts
+++ b/src/group/group.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Post, Body, HttpStatus } from '@nestjs/common';
 import { GroupService } from './group.service';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { GetGroupDto } from './dto/get-group.dto';
 
 
 @Controller('groups')
@@ -17,7 +18,7 @@ export class GroupController {
   }
 
   @ApiOperation({ summary: 'List all groups'})
-  @ApiResponse({ status: HttpStatus.OK, description: 'The group list has been returned successfully.'})
+  @ApiResponse({ status: HttpStatus.OK, description: 'The group list has been returned successfully.', type: [GetGroupDto]})
   @Get()
   findAll() {
     return this.groupService.findAll();

--- a/src/group/group.controller.ts
+++ b/src/group/group.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, HttpStatus } from '@nestjs/common';
+import { GroupService } from './group.service';
+import { CreateGroupDto } from './dto/create-group.dto';
+import { ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+
+@Controller('groups')
+export class GroupController {
+  constructor(private readonly groupService: GroupService) {}
+
+  @ApiBody({ type: CreateGroupDto })
+  @ApiOperation({ summary: 'Create group' })
+  @ApiResponse({ status: HttpStatus.CREATED, description: 'The group has been created successfully.', type: CreateGroupDto })
+  @Post()
+  create(@Body() createGroupDto: CreateGroupDto) {
+    return this.groupService.create(createGroupDto);
+  }
+
+  @ApiOperation({ summary: 'List all groups'})
+  @ApiResponse({ status: HttpStatus.OK, description: 'The group list has been returned successfully.'})
+  @Get()
+  findAll() {
+    return this.groupService.findAll();
+  }
+}

--- a/src/group/group.controller.ts
+++ b/src/group/group.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Post, Body, HttpStatus } from '@nestjs/common';
 import { GroupService } from './group.service';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';

--- a/src/group/group.module.ts
+++ b/src/group/group.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { GroupService } from './group.service';
+import { GroupController } from './group.controller';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Module({
+  controllers: [GroupController],
+  providers: [GroupService, PrismaService],
+})
+export class GroupModule {}

--- a/src/group/group.service.spec.ts
+++ b/src/group/group.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GroupService } from './group.service';
+
+describe('GroupService', () => {
+  let service: GroupService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GroupService],
+    }).compile();
+
+    service = module.get<GroupService>(GroupService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/group/group.service.ts
+++ b/src/group/group.service.ts
@@ -1,0 +1,51 @@
+import { ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { CreateGroupDto } from './dto/create-group.dto';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class GroupService {
+  constructor(private readonly prisma: PrismaService) {
+    
+  }
+  async create(data: CreateGroupDto) {
+    const {chatId, customerId} = data
+    try {
+      const foundCustomer = await this.prisma.customer.findFirst({
+        where: {
+          id: customerId
+        }
+      })
+
+      if (!foundCustomer) {
+        Logger.error('Customer not found', '', 'GroupService', true)
+        throw new NotFoundException('Customer not found')
+      }
+
+      const foundGroup = await this.prisma.group.findFirst({
+        where: {
+          chatId
+        }
+      })
+
+      if (foundGroup) {
+        Logger.error('Group already created', '', 'GroupService', true)
+        throw new ConflictException('Group already created')
+      }
+
+      const group = await this.prisma.group.create({
+        data
+      })
+
+      return group
+
+    } catch (error) {
+      Logger.error(error, '', 'CustomerService', true)
+      throw error
+    }
+    }
+
+  findAll() {
+    return this.prisma.group.findMany();
+  }
+
+}


### PR DESCRIPTION
Tenho uma nova PR para vocês revisarem:

- Criada a rota de GROUPS com os métodos POST (create) e GET (findAll), conforme task MB-64 e MB-63 do Jira.

Obs: O DTO get-group está vazio porque ele vai ser preenchido por quem fizer o método FindOne.

Checklist:

- [x] Movi o card pra Code Review no Jira

- [x] Se tiver novas envs, adicionei elas no .env.example

- [x] Documentação necessária (swagger, testes e etc)

[Card Jira - MB-64](https://makima-bot.atlassian.net/browse/MB-64)